### PR TITLE
Bump MSRV to 1.91

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        tc: [1.86.0, stable, beta, nightly]
+        tc: [1.91.0, stable, beta, nightly]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        tc: [1.86.0, stable, beta, nightly]
+        tc: [1.91.0, stable, beta, nightly]
         cc:
         - aarch64-linux-android
         - i686-pc-windows-gnu
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        tc: [1.86.0, stable, beta, nightly]
+        tc: [1.91.0, stable, beta, nightly]
         cc: [aarch64-apple-ios]
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["multimedia::encoding", "multimedia::images"]
 keywords = ["png", "encoder", "decoder", "apng", "image"]
 readme = "README.md"
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.91"
 
 [dependencies.pix]
 version = "0.14"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can use the [changelog] to facilitate upgrading this crate as a dependency.
 
 ## MSRV
 
-The current MSRV is Rust 1.86.
+The current MSRV is Rust 1.91.
 
 MSRV is updated according to the [Ardaku MSRV guidelines].
 


### PR DESCRIPTION
This is currently the maximum MSRV from MSRV policy, and is being done to keep up with the requirements of dependencies.

<!--- Please describe the changes in the PR and the motivation below -->
<!--- Check CONTRIBUTING.md for more information-->

