### PR TITLE
Switch out all instances of `R: Read` with `R: BufRead`

### DIFF
--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -1,6 +1,6 @@
 //! Read and write from a reversed bit stream
 
-use std::io::{Bytes, Read, Result, Write};
+use std::io::{BufRead, Bytes, Result, Write};
 
 /// A reversed bit stream writer.
 pub(super) struct BitstreamWriter<W: Write> {
@@ -41,7 +41,7 @@ impl<W: Write> BitstreamWriter<W> {
 }
 
 /// A reversed bit stream reader.
-pub(super) struct BitstreamReader<R: Read> {
+pub(super) struct BitstreamReader<R: BufRead> {
     /// Pointer within the stream.
     bitpointer: usize,
     /// Reader
@@ -50,11 +50,10 @@ pub(super) struct BitstreamReader<R: Read> {
     byte: Option<u8>,
 }
 
-impl<R: Read> BitstreamReader<R> {
+impl<R: BufRead> BitstreamReader<R> {
     /// Create a new `BitstreamReader` from a type that implements `Read`.
     #[inline(always)]
     pub(super) fn new(stream: R) -> Result<Self> {
-        #[expect(clippy::unbuffered_bytes)]
         let mut stream = stream.bytes();
         Ok(BitstreamReader {
             bitpointer: 0,
@@ -73,7 +72,6 @@ impl<R: Read> BitstreamReader<R> {
         stream: R,
         bitpointer: usize,
     ) -> Result<Self> {
-        #[expect(clippy::unbuffered_bytes)]
         let mut stream = stream.bytes();
         for _ in 0..bitpointer / 8 {
             stream.next().unwrap().unwrap();

--- a/src/chunk/bkgd.rs
+++ b/src/chunk/bkgd.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader, be::Read as _};
 
@@ -17,7 +17,7 @@ pub enum Background {
 }
 
 impl Background {
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         match parse.len() {

--- a/src/chunk/idat.rs
+++ b/src/chunk/idat.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use crate::{
     chunk::Chunk, consts, decode::Result as DecoderResult, decoder::Parser,
@@ -13,7 +13,7 @@ pub struct ImageData {
 }
 
 impl ImageData {
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> DecoderResult<Chunk> {
         let data = parse.raw()?;

--- a/src/chunk/ihdr.rs
+++ b/src/chunk/ihdr.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{Read, Write},
+    io::{BufRead, Write},
     num::NonZeroU32,
 };
 
@@ -107,7 +107,7 @@ impl ImageHeader {
         enc.write_crc()
     }
 
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         let buffer: [u8; 13] = parse.bytes()?;

--- a/src/chunk/itxt.rs
+++ b/src/chunk/itxt.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader};
 
@@ -28,7 +28,7 @@ pub struct InternationalText {
 
 impl InternationalText {
     /* international text chunk (iTXt) */
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         let buffer = parse.raw()?;

--- a/src/chunk/phys.rs
+++ b/src/chunk/phys.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader, be::Read as _};
 
@@ -28,7 +28,7 @@ impl Physical {
         enc.write_crc()
     }
 
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         let buffer: [u8; 9] = parse.bytes()?;

--- a/src/chunk/plte.rs
+++ b/src/chunk/plte.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader};
 use pix::rgb::{Rgb, SRgb8};
@@ -15,7 +15,7 @@ pub struct Palette {
 }
 
 impl Palette {
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         parse.set_palette();

--- a/src/chunk/text.rs
+++ b/src/chunk/text.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader};
 
@@ -18,7 +18,7 @@ pub struct Text {
 }
 
 impl Text {
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         let buffer = parse.raw()?;

--- a/src/chunk/time.rs
+++ b/src/chunk/time.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader, be::Read as _};
 
@@ -33,7 +33,7 @@ impl Time {
         enc.write_crc()
     }
 
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> Result<Chunk, DecoderError> {
         let buffer: [u8; 7] = parse.bytes()?;

--- a/src/chunk/trns.rs
+++ b/src/chunk/trns.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader, be::Read as _};
 
@@ -33,7 +33,7 @@ impl Transparency {
         }
     }
 
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> DecoderResult<Chunk> {
         if parse.has_palette() {

--- a/src/chunk/unknown.rs
+++ b/src/chunk/unknown.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use super::{Chunk, DecoderResult, EncoderResult};
 use crate::{decoder::Parser, encoder::Enc};
@@ -22,7 +22,7 @@ impl Unknown {
         enc.write_crc()
     }
 
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
         name: [u8; 4],
     ) -> DecoderResult<Chunk> {

--- a/src/chunk/ztxt.rs
+++ b/src/chunk/ztxt.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 use parsenic::{Read as _, Reader};
 
@@ -39,7 +39,7 @@ impl CompressedText {
         enc.write_crc()
     }
 
-    pub(crate) fn parse<R: Read>(
+    pub(crate) fn parse<R: BufRead>(
         parse: &mut Parser<R>,
     ) -> DecoderResult<Chunk> {
         let buffer = parse.raw()?;

--- a/src/decode/chunks.rs
+++ b/src/decode/chunks.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::BufRead;
 
 use crate::{
     chunk::{
@@ -13,12 +13,12 @@ use crate::{
 
 /// Iterator over [`Chunk`](struct.Chunk.html)s - Decoder for PNG files.
 #[derive(Debug)]
-pub struct Chunks<R: Read> {
+pub struct Chunks<R: BufRead> {
     /// Decoder
     dec: Parser<R>,
 }
 
-impl<R: Read> Chunks<R> {
+impl<R: BufRead> Chunks<R> {
     /// Create a new encoder.  Will return an error if it's not a PNG file.
     pub(crate) fn new(dec: Parser<R>) -> Self {
         Chunks { dec }
@@ -55,7 +55,7 @@ impl<R: Read> Chunks<R> {
     }
 }
 
-impl<R: Read> Iterator for Chunks<R> {
+impl<R: BufRead> Iterator for Chunks<R> {
     type Item = Result<Chunk>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/decode/steps.rs
+++ b/src/decode/steps.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Read, iter::Peekable};
+use std::{collections::HashMap, io::BufRead, iter::Peekable};
 
 use pix::{Palette, Raster};
 
@@ -27,7 +27,7 @@ struct TextEntry {
 
 /// Iterator over `Step`s for PNG files.
 #[derive(Debug)]
-pub struct Steps<R: Read> {
+pub struct Steps<R: BufRead> {
     decoder: Peekable<Chunks<R>>,
     // FIXME: This is a workaround for not supporting APNG yet.
     #[allow(dead_code)]
@@ -56,7 +56,7 @@ pub struct Steps<R: Read> {
     reject_pal: bool,
 }
 
-impl<R: Read> Steps<R> {
+impl<R: BufRead> Steps<R> {
     /// Create a new decoder.
     pub(crate) fn new(chunks: Chunks<R>) -> Self {
         let decoder = chunks.peekable();
@@ -80,7 +80,7 @@ impl<R: Read> Steps<R> {
 
 impl<R> Iterator for Steps<R>
 where
-    R: Read,
+    R: BufRead,
 {
     type Item = Result<Step, DecoderError>;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,4 @@
-use std::io::{ErrorKind, Read};
+use std::io::{BufRead, ErrorKind};
 
 use crate::{
     Step, consts,
@@ -7,7 +7,7 @@ use crate::{
 
 /// Chunk parser.
 #[derive(Debug)]
-pub(crate) struct Parser<R: Read> {
+pub(crate) struct Parser<R: BufRead> {
     /// Chunk length
     length: u32,
     /// CRC32
@@ -18,7 +18,7 @@ pub(crate) struct Parser<R: Read> {
     palette: bool,
 }
 
-impl<R: Read> Parser<R> {
+impl<R: BufRead> Parser<R> {
     /// Prepare a chunk for reading, returning it's name.
     pub(crate) fn prepare(&mut self) -> Result<Option<[u8; 4]>> {
         let first = match self.u8() {
@@ -121,12 +121,12 @@ impl<R: Read> Parser<R> {
 /// [Step]: struct.Step.html
 /// [Chunk]: chunk/enum.Chunk.html
 #[derive(Debug)]
-pub struct Decoder<R: Read> {
+pub struct Decoder<R: BufRead> {
     // The source of PNG input.
     reader: R,
 }
 
-impl<R: Read> Decoder<R> {
+impl<R: BufRead> Decoder<R> {
     /// Create a new PNG decoder.  Returns `Err` if it's not a PNG file.
     pub fn new(mut reader: R) -> Result<Self> {
         // Read first 8 bytes (PNG Signature)
@@ -160,7 +160,7 @@ impl<R: Read> Decoder<R> {
     }
 }
 
-impl<R: Read> IntoIterator for Decoder<R> {
+impl<R: BufRead> IntoIterator for Decoder<R> {
     type IntoIter = Steps<R>;
     type Item = Result<Step>;
 


### PR DESCRIPTION
<!--- Please describe the changes in the PR and the motivation below -->
<!--- Check CONTRIBUTING.md for more information-->

Removes need for expecting clippy warning / encourages better coding in the public API